### PR TITLE
Fix bugs in fields handling, and make it consistent.

### DIFF
--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -125,8 +125,37 @@ class AbstractCrudObjectTestCase(unittest.TestCase):
         del account['name']
         assert len(account._changes) == 0
 
+    def assert_fields_to_params(self):
+        """
+        Demonstrates that AbstractCrudObject._assign_fields_to_params()
+        handles various combinations of params and fields properly.
+        """
+        class Foo(objects.AbstractCrudObject):
+            _default_read_fields = ['id', 'name']
+
+        class Bar(objects.AbstractCrudObject):
+            _default_read_fields = []
+
+        for adclass, fields, params, expected in [
+            (Foo, None, {}, {'fields': 'id,name'}),
+            (Foo, None, {'a': 'b'}, {'a': 'b', 'fields': 'id,name'}),
+            (Foo, ['x'], {}, {'fields': 'x'}),
+            (Foo, ['x'], {'a': 'b'}, {'a': 'b', 'fields': 'x'}),
+            (Foo, [], {}, {}),
+            (Foo, [], {'a': 'b'}, {'a': 'b'}),
+            (Bar, None, {}, {}),
+            (Bar, None, {'a': 'b'}, {'a': 'b'}),
+            (Bar, ['x'], {}, {'fields': 'x'}),
+            (Bar, ['x'], {'a': 'b'}, {'a': 'b', 'fields': 'x'}),
+            (Bar, [], {}, {}),
+            (Bar, [], {'a': 'b'}, {'a': 'b'}),
+        ]:
+            adclass._assign_fields_to_params(fields, params)
+            assert params == expected
+
     def runTest(self):
         self.assert_delitem_changes_history()
+        self.assert_fields_to_params()
 
 
 class AbstractObjectTestCase(unittest.TestCase):


### PR DESCRIPTION
The existing handling of fields is inconsistent in the three places it 
appears: `EdgeIterator`, `AbstractCrudObject.get_by_ids` and
`AbstractCrudObject.remote_read`. The result varies between a string, a list,
None, or omitted from params.

This commit ensures that:

  1. In all cases, `params['fields']` will contain either a non-empty
    string, or will be omitted entirely.

  2. If fields is passed to a function, even an empty list, it will be
    respected rather than falling back to `get_default_read_fields`. This
    is accomplished by testing for `is None` rather than just a falsy
    value.

Additionally this uses a more common Python idiom for duplicating a dict, 
using `dict(orig)` rather than `orig.copy()`.