### PR TITLE
Don't fall through test if remote_create unexpectedly succeeds.

### DIFF
--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -517,6 +517,8 @@ class BlameFieldSpecsTestCase(AbstractCrudObjectTestCase):
             set.remote_create()
         except fbexceptions.FacebookRequestError as e:
             assert e.api_blame_field_specs() == [['campaign_group_id']]
+        else:
+            self.fail("remote_create unexpectedly succeeded")
 
 
 class AdImageTestCase(AbstractCrudObjectTestCase):


### PR DESCRIPTION
Just saw this while rebasing #23