### PR TITLE
Use tight JSON encoding in _top_level_param_json_encode

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -474,7 +474,11 @@ def _top_level_param_json_encode(params):
             isinstance(value, (collections.Mapping, collections.Sequence, bool))
             and not isinstance(value, six.string_types)
         ):
-            params[param] = json.dumps(value)
+            params[param] = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(',', ':'),
+            )
         else:
             params[param] = value
 


### PR DESCRIPTION
This accomplishes two things:

 1. Removes unnecessary spaces from the network transfer.

 2. Sorts dict keys during JSON encode so the result is stable and
   predictable for testing, HTTP traces, etc.