### PR TITLE
Fix example configuration file

### DIFF
--- a/examples/docs/config.json.example
+++ b/examples/docs/config.json.example
@@ -1,12 +1,12 @@
 {
-  'account_id': '<ACCOUNT_ID>',
-  'app_id': '<FACEBOOK_APP_ID>',
-  'app_secret': '<FACEBOOK_APP_SECRET>',
-  'image_jpg': '<IMAGE_JPG>',
-  'image_zip': '<IMAGE_ZIP>',
-  'object_id': '<OBJECT_ID>',
-  'object_url': '<OBJECT_URL>',
-  'adset_id': '<ADSET_ID>',
-  'hash_1': '<HASH_1>',
-  'hash_2': '<HASH_2>'
+  "account_id": "<ACCOUNT_ID>",
+  "app_id": "<FACEBOOK_APP_ID>",
+  "app_secret": "<FACEBOOK_APP_SECRET>",
+  "image_jpg": "<IMAGE_JPG>",
+  "image_zip": "<IMAGE_ZIP>",
+  "object_id": "<OBJECT_ID>",
+  "object_url": "<OBJECT_URL>",
+  "adset_id": "<ADSET_ID>",
+  "hash_1": "<HASH_1>",
+  "hash_2": "<HASH_2>"
 }


### PR DESCRIPTION
`examples/docs/config.json.example` has syntax error. please see below

```
$ cat config.json.example | jq .
parse error: Invalid numeric literal at line 2, column 15
```

I guess, this error comes from single quotes in config file.
Replace with `'` to `"` and I ran `jq` again.

```
$ jq . config.json.example
{
  "account_id": "<ACCOUNT_ID>",
  "app_id": "<FACEBOOK_APP_ID>",
  "app_secret": "<FACEBOOK_APP_SECRET>",
  "image_jpg": "<IMAGE_JPG>",
  "image_zip": "<IMAGE_ZIP>",
  "object_id": "<OBJECT_ID>",
  "object_url": "<OBJECT_URL>",
  "adset_id": "<ADSET_ID>",
  "hash_1": "<HASH_1>",
  "hash_2": "<HASH_2>"
}
```