### PR TITLE
Bug fix: objects build error on reach estimate

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -150,15 +150,16 @@ class EdgeIterator(object):
         return len(self._queue) > 0
 
     def build_objects_from_response(self, response):
-        if 'data' in response:
+        if 'data' in response and isinstance(response['data'], list):
             ret = []
             for json_obj in response['data']:
                 obj = self._target_objects_class()
                 obj._set_data(json_obj)
                 ret.append(obj)
         else:
+            data = response['data'] if 'data' in response else response
             obj = self._target_objects_class()
-            obj._set_data(response)
+            obj._set_data(data)
             ret = [obj]
 
         return ret

--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -595,6 +595,19 @@ class InsightsTestCase(AbstractCrudObjectTestCase):
             'level': objects.Insights.Level.adgroup,
         })
 
+class ReachEstimateTestCase(AbstractCrudObjectTestCase):
+    def test_can_read_reach_estimate_from_ad_group(self):
+        self.campaign = self.new_test_ad_campaign()
+        self.campaign.remote_create()
+
+        self.ad_set = self.new_test_ad_set(self.campaign)
+        self.ad_set.remote_create()
+
+        self.ad_group = self.new_test_ad_group(self.ad_set)
+        self.ad_group.remote_create()
+
+        self.reach_estimate = self.ad_group.get_reach_estimate()
+
 
 class BatchTestCase(FacebookAdsTestCase):
 

--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -595,6 +595,7 @@ class InsightsTestCase(AbstractCrudObjectTestCase):
             'level': objects.Insights.Level.adgroup,
         })
 
+
 class ReachEstimateTestCase(AbstractCrudObjectTestCase):
     def test_can_read_reach_estimate_from_ad_group(self):
         self.campaign = self.new_test_ad_campaign()

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -112,6 +112,36 @@ class EdgeIteratorTestCase(unittest.TestCase):
         obj = ei.build_objects_from_response(response)
         assert len(obj) == 1 and obj[0]['id'] == "601957/targetingsentencelines"
 
+    def test_builds_from_object_with_data_key(self):
+        """
+        Sometimes the response returns a single JSON object — with a "data".
+        For instamce with reachestimate. This asserts that we successfully
+        build the object that is in "data" key.
+        """
+        response = {
+            "data": {
+                "estimate_ready": True,
+                "bid_estimations": [{
+                    "cpa_min": 63,
+                    "cpa_median": 116,
+                    "cpm_max": 331,
+                    "cpc_max": 48,
+                    "cpc_median": 35,
+                    "cpc_min": 17,
+                    "cpm_min": 39,
+                    "cpm_median": 212,
+                    "unsupported": False,
+                    "location": 3,
+                    "cpa_max": 163}],
+                "users": 7600000
+            }
+        }
+        ei = objects.EdgeIterator(
+            objects.AdGroup('123'),
+            objects.ReachEstimate,
+        )
+        obj = ei.build_objects_from_response(response)
+        assert len(obj) == 1 and obj[0]['users'] == 7600000
 
 class AbstractCrudObjectTestCase(unittest.TestCase):
     def test_all_aco_has_id_field(self):

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -114,7 +114,7 @@ class EdgeIteratorTestCase(unittest.TestCase):
 
     def test_builds_from_object_with_data_key(self):
         """
-        Sometimes the response returns a single JSON object — with a "data".
+        Sometimes the response returns a single JSON object - with a "data".
         For instamce with reachestimate. This asserts that we successfully
         build the object that is in "data" key.
         """


### PR DESCRIPTION
I bumped into an error while retrieving the [ReachEstimate](https://developers.facebook.com/docs/marketing-api/reachestimate/v2.3):

```py
ag = AdGroup(1234)
ag.get_reach_estimate()
```

```py
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-15-c1833e2bb8d0> in <module>()
----> 1 ag.get_reach_estimate()

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in get_reach_estimate(self, fields, params)
   1243     def get_reach_estimate(self, fields=None, params=None):
   1244         """Returns iterator over ReachEstimate's associated with this ad."""
-> 1245         return self.iterate_edge(ReachEstimate, fields, params)
   1246 
   1247     def get_stats(self, fields=None, params=None):

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in iterate_edge(self, target_objects_class, fields, params)
    726             target_objects_class,
    727             fields=fields,
--> 728             params=params
    729         )
    730 

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in __init__(self, source_object, target_objects_class, fields, params)
     91 
     92         if self._source_object.get_api():
---> 93             self.load_next_page()
     94 
     95     def __repr__(self):

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in load_next_page(self)
    146             self._total_count = response['summary']['total_count']
    147 
--> 148         self._queue = self.build_objects_from_response(response)
    149         return len(self._queue) > 0
    150 

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in build_objects_from_response(self, response)
    154             for json_obj in response['data']:
    155                 obj = self._target_objects_class()
--> 156                 obj._set_data(json_obj)
    157                 ret.append(obj)
    158         else:

/home/web/work4us/venv/local/lib/python2.7/site-packages/facebookads/objects.pyc in _set_data(self, data)
    251         should be processed.
    252         """
--> 253         self.update(data)
    254 
    255     def export_value(self, data):

/home/web/work4us/venv/lib/python2.7/_abcoll.pyc in update(*args, **kwds)
    545                 self[key] = other[key]
    546         else:
--> 547             for key, value in other:
    548                 self[key] = value
    549         for key, value in kwds.items():

ValueError: need more than 1 value to unpack
```

I propose a fix in this PR.