### PR TITLE
Add get function for Ad Conversion Pixels

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -937,6 +937,12 @@ class AdAccount(CannotCreate, CannotDelete, AbstractCrudObject):
         """Returns iterator over Activity's associated with this account."""
         return self.iterate_edge(AdGroupStats, fields, params)
 
+    def get_ad_conversion_pixels(self, fields=None, params=None):
+        """
+        Returns iterator over AdConversionPixels associated with this account.
+        """
+        return self.iterate_edge(AdConversionPixel, fields, params)
+
     def get_ad_creatives(self, fields=None, params=None):
         """Returns iterator over AdCreative's associated with this account."""
         return self.iterate_edge(AdCreative, fields, params)


### PR DESCRIPTION
There's currently no way to get the conversion pixels for a given ad account. This PR adds the get function to allow that functionality.