### PR TITLE
Make it possible to read the version from the python package

### DIFF
--- a/facebookads/__init__.py
+++ b/facebookads/__init__.py
@@ -21,6 +21,7 @@
 from facebookads.session import FacebookSession
 from facebookads.api import FacebookAdsApi
 
+__version__ = '2.3.1'
 __all__ = [
     'session',
     'objects',

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,26 @@ try:
 except ImportError:
     from distutils.core import setup
 import os
+import re
 
 this_dir = os.path.dirname(__file__)
 readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
+package_init_filename = os.path.join(this_dir, 'facebookads/__init__.py')
+
+version = ''
+with open(package_init_filename, 'r') as handle:
+    file_content = handle.read()
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        file_content, re.MULTILINE
+    ).group(1)
+
+if not version:
+    raise RuntimeError('Cannot find version information')
 
 PACKAGE_NAME = 'facebookads'
-PACKAGE_VERSION = '2.3.1'
+PACKAGE_VERSION = version
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-ads-sdk'


### PR DESCRIPTION
I want to programmatically be able to read the version of the python package. Unfortunately for now, this information is only in the `setup.py` file. This PR tries to fix this issue and make the following possible:
```
import facebookads

print facebookads.__version__
```