### PR TITLE
Fix appsecret_proof propagation

### DIFF
--- a/facebookads/session.py
+++ b/facebookads/session.py
@@ -75,6 +75,6 @@ class FacebookSession(object):
         )
 
         self.appsecret_proof = h.hexdigest()
-
+        return self.appsecret_proof
 
 __all__ = ['FacebookSession']


### PR DESCRIPTION
Currently, the appsecret_proof doesn't get sent into the API rendering it unusable. Fix it so that the appsecret_proof gets sent in.