### PR TITLE
fixed wrong method called to get conversion stats

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1019,21 +1019,21 @@ class AdAccount(CannotCreate, CannotDelete, AbstractCrudObject):
 
     def get_conversion_stats(self, fields=None, params=None):
         """
-        Returns iterator over ConversionStats's associated with this account.
+        Returns ConversionStats object for this account.
         """
         return self.edge_object(ConversionStats, fields, params)
 
     def get_ad_campaign_conversion_stats(self, fields=None, params=None):
-        """Returns an AdCampaignConversionStats object for this account."""
-        return self.edge_object(
+        """Returns iterator over AdCampaignConversionStats objects associated this account."""
+        return self.iterate_edge(
             AdCampaignConversionStats,
             fields,
             params,
         )
 
     def get_ad_group_conversion_stats(self, fields=None, params=None):
-        """Returns an AdGroupConversionStats object for this account."""
-        return self.edge_object(AdGroupConversionStats, fields, params)
+        """Returns iterator over AdGroupConversionStats objects associated with this account."""
+        return self.iterate_edge(AdGroupConversionStats, fields, params)
 
     def get_ad_preview(self, fields=None, params=None):
         """Returns iterator over AdPreview's associated with this account."""


### PR DESCRIPTION
There was a problem with getting conversion stats for all objects of certain kinds in account - only first object in get_ad_campaign_conversion_stats (and get_ad_group_conversion_stats) was returned to user. 

Now it is EdgeIterator object.