### PR TITLE
`test_can_read_without_job` should ask for less data to the API

### DIFF
--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -670,11 +670,12 @@ class InsightsTestCase(AbstractCrudObjectTestCase):
             fields=[
                 objects.Insights.Field.unique_clicks,
                 objects.Insights.Field.impressions,
-                objects.Insights.Field.ad_id,
-                objects.Insights.Field.ad_name,
+                objects.Insights.Field.campaign_id,
+                objects.Insights.Field.campaign_name,
             ],
             params={
-                'level': objects.Insights.Level.ad,
+                'date_preset': objects.Insights.Preset.today,
+                'level': objects.Insights.Level.campaign,
             },
         )
 


### PR DESCRIPTION
Hi there,

We currently run the integration tests on our own machines and here is a quick fix for one of the tests. Before, the test queried all the data from the account at the ad level. Now it only queries the data from the day at the campaign level, which avoids responses like:
```
FacebookRequestError: 

  Message: Call was not successful
  Method:  GET
  Path:    https://graph.facebook.com/v2.4/act_xxx/insights
  Params:  {'fields': 'clicks,impressions,adgroup_id,adgroup_name', 'level': 'adgroup'}

  Status:  500
  Response:
    {
      "error": {
        "is_transient": false, 
        "error_subcode": 1504018, 
        "code": 2, 
        "error_user_msg": "Please try a smaller date range, fetch less data, or use async jobs", 
        "error_user_title": "Your request timed out", 
        "message": "Service temporarily unavailable", 
        "fbtrace_id": "Hole2dv4Rxv", 
        "type": "FacebookApiException"
      }
    }
```

Thanks!