### PR TITLE
Add status to campaign adset ad

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Campaign</a>).
 
 ```python
 campaign[objects.Campaign.Field.name] = "Potato Campain" # sic
-campaign[objects.Campaign.Field.configured_status] = objects.Campaign.Status.paused
+campaign[objects.Campaign.Field.status] = objects.Campaign.Status.paused
 ```
 
 Finally, we make the create request by calling the ``remote_create`` method.

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1313,8 +1313,9 @@ class Campaign(CanValidate, HasStatus, HasObjective, HasAdLabels, CanArchive,
         account_id = 'account_id'
         adlabels = 'adlabels'
         buying_type = 'buying_type'
-        configured_status = 'configured_status'
-        effective_status = 'effective_status'
+        status = 'status'  # Write-only attribute
+        configured_status = 'configured_status'  # Read-only attribute
+        effective_status = 'effective_status'  # Read-only attribute
         id = 'id'
         is_completed = 'is_completed'
         name = 'name'

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1486,6 +1486,7 @@ class Ad(HasStatus, CanArchive, HasAdLabels, AbstractCrudObject):
         name = 'name'
         redownload = 'redownload'
         social_prefs = 'social_prefs'
+        status = 'status'
         tracking_specs = 'tracking_specs'
         updated_time = 'updated_time'
         view_tags = 'view_tags'

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1388,7 +1388,7 @@ class AdSet(CanValidate, HasStatus, CanArchive, HasAdLabels,
         rf_prediction_id = 'rf_prediction_id'
         rtb_flag = 'rtb_flag'
         start_time = 'start_time'
-        status = 'status'  # Write only attribute
+        status = 'status'  # Write-only attribute
         targeting = 'targeting'
         updated_time = 'updated_time'
 
@@ -1486,7 +1486,7 @@ class Ad(HasStatus, CanArchive, HasAdLabels, AbstractCrudObject):
         name = 'name'
         redownload = 'redownload'
         social_prefs = 'social_prefs'
-        status = 'status'
+        status = 'status'  # Write-only attribute
         tracking_specs = 'tracking_specs'
         updated_time = 'updated_time'
         view_tags = 'view_tags'

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1388,6 +1388,7 @@ class AdSet(CanValidate, HasStatus, CanArchive, HasAdLabels,
         rf_prediction_id = 'rf_prediction_id'
         rtb_flag = 'rtb_flag'
         start_time = 'start_time'
+        status = 'status'  # Write only attribute
         targeting = 'targeting'
         updated_time = 'updated_time'
 


### PR DESCRIPTION
In version 2.5 of the facebook marketing api `status` was split into `effective_status` and `configured_status` on the read path. However it stayed as `status` on the write path.

This PR adds `status` to the `Fields` of the objects:

- `Campaign`
- `Adset`
- `Ad`

This change was discussed in issue #113.