### PR TITLE
Fix Field value in AdImage

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1737,10 +1737,13 @@ class AdImage(CannotUpdate, AbstractCrudObject):
 
     class Field(object):
         creatives = 'creatives'
-        filename = 'filename'
+        name = 'name'
         hash = 'hash'
         id = 'id'
         url = 'url'
+        height = 'height'
+        width = 'width'
+        created_time = 'created_time'
 
     @classmethod
     def get_endpoint(cls):


### PR DESCRIPTION
Summary: Use the correct AdImage.Field value for filename. Added additional useful Fields for AdImage

Test Plan: none
