### PR TITLE
Add missing Field properties for AdImages

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1732,7 +1732,7 @@ class AdCreative(HasAdLabels, AbstractCrudObject):
 class AdImage(CannotUpdate, AbstractCrudObject):
 
     """
-        Represnts the image for ad creative
+        Represents the image for ad creative
     """
 
     class Field(object):
@@ -1741,6 +1741,17 @@ class AdImage(CannotUpdate, AbstractCrudObject):
         hash = 'hash'
         id = 'id'
         url = 'url'
+        account_id = 'account_id'
+        created_time = 'created_time'
+        height = 'height'
+        name = 'name'
+        original_height = 'original_height'
+        original_width = 'original_width'
+        permalink_url = 'permalink_url'
+        status = 'status'
+        updated_time = 'updated_time'
+        url_128 = 'url_128'
+        width = 'width'
 
     @classmethod
     def get_endpoint(cls):
@@ -1850,7 +1861,7 @@ class AdImage(CannotUpdate, AbstractCrudObject):
         """
         if not self[self.Field.filename]:
             raise FacebookBadObjectError(
-                "AdImage required a filename to be defined.",
+                "AdImage requires a filename to be defined.",
             )
         filename = self[self.Field.filename]
         with open(filename, 'rb') as open_file:


### PR DESCRIPTION
Summary: Added all missing field properties as defined in the api reference docs. Left the 'filename'
property as is since it's more descriptive than 'name' when creating the AdImage.

Test Plan: none
