### PR TITLE
Fixing GET and DELETE batch requests

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -393,7 +393,11 @@ class FacebookAdsApiBatch(object):
             params = _top_level_param_json_encode(params)
             keyvals = ['%s=%s' % (key, urls.quote_with_encoding(value))
                        for key, value in params.items()]
-            call['body'] = '&'.join(keyvals)
+            payload = '&'.join(keyvals)
+            if method in ('POST', 'PUT'):
+                call['body'] = payload
+            else:
+                call['relative_url'] = '{0}?{1}'.format(relative_url, payload)
 
         if files:
             call['attached_files'] = ','.join(files.keys())

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -431,8 +431,26 @@ class FacebookAdsApiBatchTestCase(unittest.TestCase):
         self.assertEqual(len(batch_api), 1)
         self.assertEqual(batch_api._batch[0], {
             'method': 'GET',
+            'relative_url': (
+                'some/path?key=' + utils.urls.quote_with_encoding(u'vàlué'))
+        })
+
+    def test_add_puts_payload_in_body_for_post_and_put(self):
+        default_api = api.FacebookAdsApi.get_default_api()
+        batch_api = api.FacebookAdsApiBatch(default_api)
+        params = {"key1": "value1", "key2": "value2"}
+        body = '&'.join([k + '=' + v for k, v in params.iteritems()])
+        batch_api.add('POST', 'some/path', params=params)
+        self.assertEqual(batch_api._batch[0], {
+            'method': 'POST',
             'relative_url': 'some/path',
-            'body': 'key=' + utils.urls.quote_with_encoding(u'vàlué')
+            'body': body
+        })
+        batch_api.add('PUT', 'some/path', params=params)
+        self.assertEqual(batch_api._batch[1], {
+            'method': 'PUT',
+            'relative_url': 'some/path',
+            'body': body
         })
 
 


### PR DESCRIPTION
As stated in https://developers.facebook.com/docs/graph-api/making-multiple-requests#multiple_methods:

> While GET and DELETE operations must only have a relative_url and a method field, POST and PUT operations may contain an optional body field.

This fixes #156, fixes #152, fixes #8