### PR TITLE
AbstractObject.__init__ initializes _data with `None` key.

### DIFF
--- a/facebookads/adobjects/abstractobject.py
+++ b/facebookads/adobjects/abstractobject.py
@@ -40,7 +40,10 @@ class AbstractObject(collections.MutableMapping):
         pass
 
     def __init__(self):
-        self._data = dict.fromkeys(self.Field.__dict__.values())
+        field_dict = self.Field.__dict__.copy()
+        field_dict.pop('__doc__', None)
+        field_dict.pop('__module__', None)
+        self._data = dict.fromkeys(field_dict.values())
         self._field_checker = TypeChecker(self._field_types,
             self._get_field_enum_info())
 

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -281,6 +281,11 @@ class AbstractCrudObjectTestCase(unittest.TestCase):
 
 
 class AbstractObjectTestCase(unittest.TestCase):
+    def test_init(self):
+        obj = objects.Campaign()
+        self.assertNotIn(None, obj._data)
+        self.assertNotIn("facebookads.adobjects.campaign", obj._data)
+
     def test_export_nested_object(self):
         obj = specs.ObjectStorySpec()
         obj2 = specs.OfferData()


### PR DESCRIPTION
Hi there,

I found this bug in **2.6.2**, easy to reproduce:
```python
from facebookads.adobjects.campaign import Campaign
c = Campaign()
c.items()  # or dict(c) or whatever
```
Will raise the following:
```
KeyError: 'None'
```
The issue comes from this [line](https://github.com/facebook/facebook-python-ads-sdk/blob/2.6.2/facebookads/adobjects/abstractobject.py#L43). `Field.__dict__.values()` will contain `None` in the majority of cases (it takes `__doc__` which is equal to `None` and `__module__` from the dict). And the fact that the keys are coerced to strings [here](https://github.com/facebook/facebook-python-ads-sdk/blob/2.6.2/facebookads/adobjects/abstractobject.py#L47-L48) doesn't help... So here is a PR to fix it. I'd advise to fix the root problem which is the string coercion but I don't want to mess up your data model.

N.B.: `AbstractObject` inherits from `collections.MutableMapping` that's why we have access to those dict-like methods.

Cheers