### PR TITLE
ad.tracking_spec type should be `list<ConversionActionQuery>`, not `Object`

### DIFF
--- a/facebookads/adobjects/ad.py
+++ b/facebookads/adobjects/ad.py
@@ -201,7 +201,7 @@ class Ad(
             'name': 'string',
             'redownload': 'bool',
             'status': 'status_enum',
-            'tracking_specs': 'Object',
+            'tracking_specs': 'list<ConversionActionQuery>',
         }
         enums = {
             'execution_options_enum': Ad.ExecutionOptions.__dict__.values(),


### PR DESCRIPTION
Hi @rituparnamukherjee @JiamingFB 

Here is a small fix that we did on our 2.6 fork and I see it's not included in your repository (nothing in the `2.7` tag). Can you merge this or do dark magic on your generation scripts? Thanks.

(This week I'm migrating to 2.7 version so by advance sorry for the multiple issues i'll open x) )