### PR TITLE
Issue 263 (Optionally Initialize FacebookSession With Proxies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ from facebookads import objects
 my_app_id = '<APP_ID>'
 my_app_secret = '<APP_SECRET>'
 my_access_token = '<ACCESS_TOKEN>'
-FacebookAdsApi.init(my_app_id, my_app_secret, my_access_token)
+proxies = {'http': '<HTTP_PROXY>', 'https': '<HTTPS_PROXY>'} # add proxies if needed
+FacebookAdsApi.init(my_app_id, my_app_secret, my_access_token, proxies)
 ```
 
 **NOTE**: We shall use the objects module throughout the rest of the tutorial. You can 
@@ -287,17 +288,20 @@ my_app_id = '<APP_ID>'
 my_app_secret = '<APP_SECRET>'
 my_access_token_1 = '<ACCESS_TOKEN_1>'
 my_access_token_2 = '<ACCESS_TOKEN_2>'
+proxies = {'http': '<HTTP_PROXY>', 'https': '<HTTPS_PROXY>'} # add proxies if needed
 
 session1 = FacebookSession(
     my_app_id,
     my_app_secret,
     my_access_token_1,
+    proxies,
 )
 
 session2 = FacebookSession(
     my_app_id,
     my_app_secret,
     my_access_token_2,
+    proxies,
 )
 
 api1 = FacebookAdsApi(session1)
@@ -329,6 +333,7 @@ session = FacebookSession(
  my_app_id,
  my_app_secret,
  my_access_token_1,
+ proxies,
 )
 
 api = FacebookAdsApi(session1)

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -189,9 +189,10 @@ class FacebookAdsApi(object):
         app_secret=None,
         access_token=None,
         account_id=None,
-        api_version=None
+        api_version=None,
+        proxies=None
     ):
-        session = FacebookSession(app_id, app_secret, access_token)
+        session = FacebookSession(app_id, app_secret, access_token, proxies)
         api = cls(session, api_version)
         cls.set_default_api(api)
 

--- a/facebookads/session.py
+++ b/facebookads/session.py
@@ -39,20 +39,22 @@ class FacebookSession(object):
         app_secret: The application secret.
         access_token: The access token.
         appsecret_proof: The application secret proof.
+        proxies: Object containing proxies for 'http' and 'https'
         requests: The python requests object through which calls to the api can
             be made.
     """
     GRAPH = 'https://graph.facebook.com'
 
-    def __init__(self, app_id=None, app_secret=None, access_token=None):
+    def __init__(self, app_id=None, app_secret=None, access_token=None, proxies=None):
         """
         Initializes and populates the instance attributes with app_id,
-        app_secret, access_token, appsecret_proof, and requests given arguments
-        app_id, app_secret, and access_token.
+        app_secret, access_token, appsecret_proof, proxies, and requests given arguments
+        app_id, app_secret, access_token and proxies.
         """
         self.app_id = app_id
         self.app_secret = app_secret
         self.access_token = access_token
+        self.proxies = proxies
 
         self.requests = requests.Session()
         self.requests.verify = os.path.join(
@@ -65,6 +67,9 @@ class FacebookSession(object):
         if app_secret:
             params['appsecret_proof'] = self._gen_appsecret_proof()
         self.requests.params.update(params)
+
+        if self.proxies:
+            self.requests.proxies.update(self.proxies)
 
     def _gen_appsecret_proof(self):
         h = hmac.new(


### PR DESCRIPTION
Feature: Allows the FacebookSession (and FacebookAdsApi) to be initialized with proxies.
- Added an optional parameter called `proxies` to `FacebookSession`'s `__init__` function
- Updated Session with proxies if proxies are received
- Added `proxies` parameter to `FacebookAdsApi.init` and used it to init the `FacebookSession`
- The `proxies` parameter is always defaulted to `None`
- The `proxies` argument should be an object formatted as follows: `{'http': '<HTTP_PROXY>', 'https': '<HTTPS_PROXY>'}` (conform to this: http://docs.python-requests.org/en/master/user/advanced/#proxies)
- Added relevant documentation

I tested the code on a server with proxies and it works fine. Ready for merge.

For reference see #263 
