### PR TITLE
Load batch responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,10 +384,21 @@ Calls can be added to the batch instead of being executed immediately:
 campaign.remote_delete(batch=my_api_batch)
 ```
 
+Requests can be saved to load the response after the batch call:
+
+```python
+request = campaign.get_insights(batch=my_api_batch)
+```
+
 Once you're finished adding calls to the batch, you can send off the request:
 
 ```python
 my_api_batch.execute()
+```
+
+After the batch call you may load your response: 
+```python
+response = request.load()
 ```
 
 Please follow <a href="https://developers.facebook.com/docs/graph-api/making-multiple-requests">

--- a/facebookads/adobjects/abstractcrudobject.py
+++ b/facebookads/adobjects/abstractcrudobject.py
@@ -343,10 +343,14 @@ class AbstractCrudObject(AbstractObject):
 
                 if success:
                     success(response)
+                else: 
+                    request.callback(response)
 
             def callback_failure(response):
                 if failure:
                     failure(response)
+                else: 
+                    request.callback(response)
 
             batch_call = batch.add_request(
                 request=request,
@@ -409,10 +413,14 @@ class AbstractCrudObject(AbstractObject):
 
                 if success:
                     success(response)
+                else: 
+                    request.callback(response)
 
             def callback_failure(response):
                 if failure:
                     failure(response)
+                else: 
+                    request.callback(response)
 
             batch_call = batch.add_request(
                 request=request,
@@ -465,10 +473,14 @@ class AbstractCrudObject(AbstractObject):
 
                 if success:
                     success(response)
+                else: 
+                    request.callback(response)
 
             def callback_failure(response):
                 if failure:
                     failure(response)
+                else: 
+                    request.callback(response)    
 
             batch_call = batch.add_request(
                 request=request,

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -674,7 +674,7 @@ class FacebookRequest:
         batch.add_request(self, success, failure)
 
     def callback(self, response): 
-       self._response = response
+        self._response = response
 
     def load(self): 
         if self._response is None:
@@ -684,7 +684,7 @@ class FacebookRequest:
 
         params = copy.deepcopy(self._params)
         if self._response.error():
-            raise response.error()
+            raise self._response.error()
         elif self._api_type == "EDGE" and self._method == "GET":
             response = self._response.json()
             cursor = Cursor(

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -421,6 +421,9 @@ class FacebookAdsApiBatch(object):
                 batch_formatted_header['value'] = headers[header]
                 call['headers'].append(batch_formatted_header)
 
+        success = request.callback if success is None else success
+        failure = request.callback if failure is None else failure
+
         self._batch.append(call)
         self._files.append(files)
         self._success_callbacks.append(success)
@@ -570,6 +573,7 @@ class FacebookRequest:
         self._api_version = api_version
         self._params = {}
         self._fields = []
+        self._response = None
         self._file_params = {}
         self._file_counter = 0
         self._accepted_fields = []
@@ -667,6 +671,44 @@ class FacebookRequest:
 
     def add_to_batch(self, batch, success=None, failure=None):
         batch.add_request(self, success, failure)
+
+    def callback(self, response): 
+       self._response = response
+
+    def load(self): 
+        params = copy.deepcopy(self._params)
+        if self._response.error():
+            raise response.error()
+        elif self._api_type == "EDGE" and self._method == "GET":
+            response = self._response.json()
+            cursor = Cursor(
+                    target_objects_class=self._target_class,
+                    params=params,
+                    fields=self._fields,
+                    include_summary=self._include_summary,
+                    api=self._api,
+                    node_id=self._node_id,
+                    endpoint=self._endpoint,
+                )
+
+            if 'paging' in response and 'next' in response['paging']:
+                cursor._path = response['paging']['next']
+            else:
+                cursor._finished_iteration = True
+
+            if (
+                cursor._include_summary and
+                'summary' in response and
+                'total_count' in response['summary']
+            ):
+                cursor._total_count = response['summary']['total_count']
+
+            cursor._queue = cursor.build_objects_from_response(response)
+            return cursor
+        elif self._response_parser:
+            return self._response_parser.parse_single(self._response.json())
+        else:
+            return self._response.json()
 
     def _extract_value(self, value):
         if hasattr(value, 'export_all_data'):

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -676,6 +676,11 @@ class FacebookRequest:
        self._response = response
 
     def load(self): 
+        if self._response is None:
+            raise FacebookUnavailablePropertyException(
+                "Couldn't retrieve the response for this request"
+            )
+
         params = copy.deepcopy(self._params)
         if self._response.error():
             raise response.error()

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -421,8 +421,9 @@ class FacebookAdsApiBatch(object):
                 batch_formatted_header['value'] = headers[header]
                 call['headers'].append(batch_formatted_header)
 
-        success = request.callback if success is None else success
-        failure = request.callback if failure is None else failure
+        if request: 
+            success = request.callback if success is None else success
+            failure = request.callback if failure is None else failure
 
         self._batch.append(call)
         self._files.append(files)


### PR DESCRIPTION
Loading objects that result from batch requests, more specifically this is useful for paginated insight responses which can be iterated in the same way as single request insights responses . 

Example: 
```python
my_api_batch = api.new_batch()
request = campaign.get_insights(batch=my_api_batch)
my_api_batch.execute()
insights = request.load()
```
