### PR TITLE
setup.py including PNG instead of JPG for test package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ PACKAGES = [
 ]
 PACKAGE_DATA = {
     'facebookads': ['*.crt'],
-    'facebookads.test': ['*.jpg']
+    'facebookads.test': ['*.png']
 }
 PACKAGE_LICENSE = 'LICENSE.txt'
 PACKAGE_DESCRIPTION = 'Facebook Ads API SDK'


### PR DESCRIPTION
There are no JPGs in the test package. However there is a [test.png](https://github.com/facebook/facebook-python-ads-sdk/blob/master/facebookads/test/test.png) which is referenced in [integration.py](https://github.com/facebook/facebook-python-ads-sdk/blob/master/facebookads/test/integration.py#L317).

When installing via `pip` or `python setup.py install`, `test.png` needs to be included in the install for integration tests to work. Otherwise running `python -m facebookads.test.integration` will result in a bunch of `IOError: [Errno 2] No such file or directory` exceptions.