### PR TITLE
Add Capabilities fields according to v2.8 doc.

### DIFF
--- a/facebookads/adobjects/helpers/adaccountmixin.py
+++ b/facebookads/adobjects/helpers/adaccountmixin.py
@@ -35,7 +35,8 @@ class AdAccountMixin:
 
     class Capabilities(object):
         bulk_account = 'BULK_ACCOUNT'
-        can_create_lookalikes_with_custom_ratio = 'CAN_CREATE_LOOKALIKES_WITH_CUSTOM_RATIO'
+        can_create_lookalikes_with_custom_ratio = ('CAN_CREATE_LOOKALIKES'
+                                                   '_WITH_CUSTOM_RATIO')
         can_use_conversion_lookalikes = 'CAN_USE_CONVERSION_LOOKALIKES'
         can_use_reach_and_frequency = 'CAN_USE_REACH_AND_FREQUENCY'
         custom_audiences_folders = 'CUSTOM_AUDIENCES_FOLDERS'

--- a/facebookads/adobjects/helpers/adaccountmixin.py
+++ b/facebookads/adobjects/helpers/adaccountmixin.py
@@ -34,10 +34,16 @@ class AdAccountMixin:
         pass
 
     class Capabilities(object):
+        bulk_account = 'BULK_ACCOUNT'
+        can_create_lookalikes_with_custom_ratio = 'CAN_CREATE_LOOKALIKES_WITH_CUSTOM_RATIO'
+        can_use_conversion_lookalikes = 'CAN_USE_CONVERSION_LOOKALIKES'
+        can_use_reach_and_frequency = 'CAN_USE_REACH_AND_FREQUENCY'
         custom_audiences_folders = 'CUSTOM_AUDIENCES_FOLDERS'
         custom_audiences_opt_out_link = 'CUSTOM_AUDENCES_OPT_OUT_LINK'
         custom_cluster_sharing = 'CUSTOM_CLUSTER_SHARING'
         direct_sales = 'DIRECT_SALES'
+        has_available_payment_methods = 'HAS_AVAILABLE_PAYMENT_METHODS'
+        holdout_view_tags = 'HOLDOUT_VIEW_TAGS'
         lookalike_audience = 'LOOKALIKE_AUDIENCE'
         new_campaign_structure = 'NEW_CAMPAIGN_STRUCTURE'
         premium = 'PREMIUM'


### PR DESCRIPTION
There are some missing fields on Capabilities class in file `facebookads/adobjects/helpers/adaccountmixin.py`:

eg,


 `BULK_ACCOUNT`, `CAN_CREATE_LOOKALIKES_WITH_CUSTOM_RATIO`, `HAS_AVAILABLE_PAYMENT_METHODS`, etc.


Doc reference: https://developers.facebook.com/docs/marketing-api/reference/ad-account/capabilities/v2.8

Actually, there are even more fields remained undocumented. When I tired with my ad account, using Graph API Explorer, it turns out to be this:
```
{
  "capabilities": [
    "CAN_USE_MOBILE_EXTERNAL_PAGE_TYPE",
    "CAN_USE_MOBILE_EXTERNAL_PAGE_TYPE_FOR_LPP",
    "CAN_USE_INSTANT_ARTICLE",
    "CAN_USE_OLD_AD_TYPES",
    "OFFSITE_CONVERSION_HIGH_BID",
    "PRORATED_BUDGET",
    "SYNDICATED_AUDIENCE",
    "CAN_USE_MOBILE_EXTERNAL_PAGE_TYPE_FOR_VIDEO_VIEWS",
    "CAN_USE_DELIVERY_DASHBOARD",
    "CAN_SHOW_DELIVERY_INSIGHTS_LINK",
    "CAN_SHOW_DELIVERY_DASHBOARD_KPI_CARD",
    "CAN_SHOW_DELIVERY_TRUST_PRODUCTS",
    "ADS_PE_CANVAS_CAN_SAVE_INCOMPLETE_ELEMENTS",
    "ADS_PE_CANVAS_CAN_USE_TEMPLATE_V1",
    "ADS_PE_CANVAS_CAN_USE_LINKED_CANVAS",
    "CAN_USE_RECURRING_BUDGET",
    "CAN_USE_AUTO_CAROUSEL_OPTION",
    "CAN_USE_AUTO_CAROUSEL_WITHOUT_CATALOG",
    "PREMIUM",
    "CAN_OVERRIDE_PAGE_ACTOR",
    "CAN_CREATE_BRAND_AWARENESS_OBJECTIVE_ADS",
    "ADS_RULES_PAUSE_ACTION",
    "ADS_RULES_SEND_EMAIL_ACTION",
    "ADS_RULES_DYNAMIC",
    "ADS_RULES_ATTRIBUTION_WINDOW",
    "ADS_TARGETING_USE_DEVICE_MARKETING_NAME",
    "ADS_PE_STORE_LOCATIONS",
    "ADS_TEX_POST_ENGAGEMENT_ACCOUNTS",
    "LEAD_GEN_FORM_CREATED_BY_API",
    "ADS_CF_VIDEO_LPP_BAO_CREATION",
    "ADS_CF_VIDEO_LPP_VV_CREATION",
    "ADS_CF_VIDEO_LPP_WEBSITE_CREATION",
    "ADS_PE_BAO_MOVE_LINK_TOGGLE",
    "ADS_PE_MEDIA_SELECTOR_FIRST_FOR_CAROUSEL",
    "ADS_PE_MEDIA_SELECTOR_FIRST_FOR_WEBSITE",
    "ADS_PE_SLIDESHOW_ENTRYPOINT",
    "LEAD_GEN_BUSINESS_VERTICALS",
    "LEAD_GEN_BUSINESS_VERTICAL_TEST",
    "LEADGEN_FORM_CONTEXT_PAGE",
    "PE_WEBSITE_CANVAS",
    "PE_NEKO_CANVAS",
    "ADS_RF_EDIT_MID_CAMPAIGN",
    "CAN_USE_TARGETING_SPEC_RELAX_UI",
    "ADS_WEB_CONVERSIONS_MESSAGE_PAGE_CTA",
    "ADS_WEB_CLICKS_MESSAGE_PAGE_CTA",
    "MESSAGE_CTA_WELCOME_MESSAGE_CREATION",
    "IG_ADS_VIDEO_SUBTITLES_ENABLED",
    "ADS_PE_WEBSITE_MESSENGER_DESTINATION",
    "PE_WEBSITE_CAROUSEL_CANVAS",
    "ADS_WEB_CLICKS_OBJECTIVE_MESSENGER_UI",
    "ADS_SPLIT_TEST_TRAFFIC",
    "ADS_DELIVERY_CONTAINER_CREATION",
    "ADS_DELIVERY_CONTAINER_MANAGEMENT",
    "CAN_ACCOUNT_USE_CAMPAIGN_FILTER",
    "CAN_CREATE_INSTAGRAM_LEAD_GEN_ADS",
    "ADS_MESSENGER_DESTINATION_JSON_ACCOUNT",
    "ADS_AUTOMATED_BRAND_LIFT",
    "CAN_USE_FAN_INSTERSTITIAL_IN_VIDEO_VIEWS",
    "CAN_USE_LINK_CLICK_BILLING_EVENT",
    "ADS_MESSENGER_DESTINATION_SEND_JSON_ACCOUNT",
    "ADS_CONVERSION_MESSENGER_DESTINATION_ACCOUNTS",
    "ADS_CAROUSEL_MESSENGER_DESTINATION_ACCOUNT",
    "CF_AUTO_CAROUSEL_WITHOUT_CATALOG_CAPABILITY",
    "CAN_CREATE_INSTAGRAM_STORY_ADS",
    "CAN_SEE_NEW_CONVERSION_WINDOW_NUX",
    "ADS_SPLIT_TEST_EARLY_WINNER",
    "ADS_MULTICOUNTRY_LOOKALIKES",
    "ADS_DISABLE_CONVERSION_TRACKING_PIXEL",
    "ADS_CF_BULK_CREATION",
    "ADS_PLACEMENT_INSTANT_ARTICLE_PPE",
    "ADS_BUDGET_MODE_CHANGE_NOT_RESET_ENDTIME",
    "ADS_CF_OFFERS_IN_TRAFFICS_OR_CONVERSIONS"
  ],
  "id": "act_my_ad_account_id"
}
```
