### PR TITLE
Add option to override default requests timeout

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -193,7 +193,8 @@ class FacebookAdsApi(object):
         proxies=None,
         timeout=None
     ):
-        session = FacebookSession(app_id, app_secret, access_token, proxies, timeout)
+        session = FacebookSession(app_id, app_secret, access_token, proxies,
+                                  timeout)
         api = cls(session, api_version)
         cls.set_default_api(api)
 

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -190,9 +190,10 @@ class FacebookAdsApi(object):
         access_token=None,
         account_id=None,
         api_version=None,
-        proxies=None
+        proxies=None,
+        timeout=None
     ):
-        session = FacebookSession(app_id, app_secret, access_token, proxies)
+        session = FacebookSession(app_id, app_secret, access_token, proxies, timeout)
         api = cls(session, api_version)
         cls.set_default_api(api)
 
@@ -300,6 +301,7 @@ class FacebookAdsApi(object):
                 params=params,
                 headers=headers,
                 files=files,
+                timeout=self._session.timeout
             )
         else:
             response = self._session.requests.request(
@@ -308,6 +310,7 @@ class FacebookAdsApi(object):
                 data=params,
                 headers=headers,
                 files=files,
+                timeout=self._session.timeout
             )
         fb_response = FacebookResponse(
             body=response.text,

--- a/facebookads/session.py
+++ b/facebookads/session.py
@@ -45,16 +45,17 @@ class FacebookSession(object):
     """
     GRAPH = 'https://graph.facebook.com'
 
-    def __init__(self, app_id=None, app_secret=None, access_token=None, proxies=None):
+    def __init__(self, app_id=None, app_secret=None, access_token=None, proxies=None, timeout=None):
         """
         Initializes and populates the instance attributes with app_id,
-        app_secret, access_token, appsecret_proof, proxies, and requests given arguments
-        app_id, app_secret, access_token and proxies.
+        app_secret, access_token, appsecret_proof, proxies, timeout and requests given arguments
+        app_id, app_secret, access_token, proxies and timeout.
         """
         self.app_id = app_id
         self.app_secret = app_secret
         self.access_token = access_token
         self.proxies = proxies
+        self.timeout = timeout
 
         self.requests = requests.Session()
         self.requests.verify = os.path.join(

--- a/facebookads/session.py
+++ b/facebookads/session.py
@@ -45,11 +45,12 @@ class FacebookSession(object):
     """
     GRAPH = 'https://graph.facebook.com'
 
-    def __init__(self, app_id=None, app_secret=None, access_token=None, proxies=None, timeout=None):
+    def __init__(self, app_id=None, app_secret=None, access_token=None,
+                 proxies=None, timeout=None):
         """
         Initializes and populates the instance attributes with app_id,
-        app_secret, access_token, appsecret_proof, proxies, timeout and requests given arguments
-        app_id, app_secret, access_token, proxies and timeout.
+        app_secret, access_token, appsecret_proof, proxies, timeout and requests
+        given arguments app_id, app_secret, access_token, proxies and timeout.
         """
         self.app_id = app_id
         self.app_secret = app_secret


### PR DESCRIPTION
Currently there is no way to let the requests timeout if something bad
happens. That can stuck any code using this library.