### PR TITLE
[#368] fix is_success false positive when html body in response.

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -96,6 +96,8 @@ class FacebookResponse(object):
         if isinstance(json_body, collections.Mapping) and 'error' in json_body:
             # Is a dictionary, has error in it
             return False
+        elif self._http_status >= 400:
+            return False
         elif bool(json_body):
             # Has body and no error
             if 'success' in json_body:

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -498,5 +498,16 @@ class FacebookResponseTestCase(unittest.TestCase):
         resp = api.FacebookResponse(body="Service Unavailable", http_status=200)
         self.assertFalse(resp.is_success())
 
+    def test_is_success_not_modified(self):
+        resp = api.FacebookResponse(http_status=304)
+        self.assertTrue(resp.is_success())
+
+    def test_is_failure_for_html_body(self):
+        html_body = '<html><head></head><body>' \
+                    '<p>Something went wrong!</p>' \
+                    '</body></html>'
+        resp = api.FacebookResponse(http_status=400, body=html_body)
+        self.assertFalse(resp.is_success())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should resolve this issue: https://github.com/facebook/facebook-python-ads-sdk/issues/368
Test reproduces what I was seeing. See comment in thread for more details.

In my app code the failure was getting swallowed. Usage here:
```
res = audience.remove_users(schema, users, is_raw=True)
logger.info('Got: %s. %s' % (res.status(), res.body()))
if res.is_failure():
    raise res.error()
```

This is my first contribution to this repository so let me know if I need to revise anything prior to merging. Thanks!