### PR TITLE
Removed deprecated py33, added py35 and py36

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
Travis/tox was failing because python3.3 build environment no longer available, also added some of the newer ones.