### PR TITLE
Fix failing Travis CI builds and test more recent Python environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py36
+  - TOX_ENV=py35
   - TOX_ENV=py34
-  - TOX_ENV=py33
   - TOX_ENV=py27
+  - TOX_ENV=pypy
+  - TOX_ENV=pypy3
 install:
   - pip install tox 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ python:
   - "pypy"
   - "pypy3"
 
+install:
+  - pip install tox-travis  # leaving out of requirements.txt b/c only needed by travis
+
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ python:
   - "2.7"
   - "pypy"
   - "pypy3"
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false  # allows use of faster container-based builds
+
 language: python
 python: 2.7
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ dist: trusty
 sudo: false  # allows use of faster container-based builds
 
 language: python
-python: 2.7
-env:
+python:
   - "3.5"
   - "3.4"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,8 @@ sudo: false  # allows use of faster container-based builds
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py36
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py27
-  - TOX_ENV=pypy
-  - TOX_ENV=pypy3
-install:
-  - pip install tox 
-script:
-  - tox -e $TOX_ENV
+  - "3.5"
+  - "3.4"
+  - "2.7"
+  - "pypy"
+  - "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false  # allows use of faster container-based builds
 
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - "pypy3"
 
 install:
-  - pip install tox-travis  # leaving out of requirements.txt b/c only needed by travis
+  - pip install tox tox-travis  # leaving out of requirements.txt b/c only needed by travis
 
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py27,py34,py35,py36,pypy,pypy3
-
 [testenv]
 commands =
     {envpython} -m facebookads.test.unit

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
* removed deprecated py33, added py35,py36,pypy,pypy3
* used tox-travis to test different python environments instead of $TOX_ENV variables

Sorry for the messy commit history, it took a few tries to make Travis happy. You can either do a squash+merge, or let me know if you'd like me to redo the PR.